### PR TITLE
Fix lazyImport returning prototype property

### DIFF
--- a/src/utils/__tests__/lazyImport.test.tsx
+++ b/src/utils/__tests__/lazyImport.test.tsx
@@ -1,0 +1,12 @@
+import React from 'react'
+import { describe, it, expect } from 'vitest'
+import { lazyImport } from '../lazyImport'
+
+describe('lazyImport', () => {
+  it('returns object with own enumerable property', () => {
+    const factory = () => Promise.resolve({ Dummy: () => React.createElement('div') })
+    const imported = lazyImport(factory, 'Dummy')
+    expect(Object.keys(imported)).toContain('Dummy')
+    expect(imported.Dummy).toBeDefined()
+  })
+})

--- a/src/utils/lazyImport.ts
+++ b/src/utils/lazyImport.ts
@@ -7,12 +7,12 @@ import React from 'react';
  */
 export function lazyImport<
   T extends React.ComponentType<any>,
-  I extends { [K2 in K]: T },
+  I extends Record<K, T>,
   K extends keyof I
->(factory: () => Promise<I>, name: K): I {
-  return Object.create({
+>(factory: () => Promise<I>, name: K): Pick<I, K> {
+  return {
     [name]: React.lazy(() => factory().then((module) => ({ default: module[name] }))),
-  });
+  } as Pick<I, K>;
 }
 
 /**


### PR DESCRIPTION
## Summary
- ensure `lazyImport` returns component as own enumerable property
- add unit test for lazyImport enumerability

## Testing
- `npm test` *(fails: Permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_6895b03c9c988331ab62c698c219b978